### PR TITLE
feat: 自定义登录页 + BrowserRouter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     volumes:
       - ./data:/data
       - ./htpasswd:/etc/nginx/htpasswd
-      - ./lua:/lua
-      - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
     environment:
       - INTERVAL=60
     ports:

--- a/src/routes/AppLayout.jsx
+++ b/src/routes/AppLayout.jsx
@@ -5,16 +5,19 @@
  * 视觉风格：Indigo（紫蓝）主题，分组式侧边栏，悬浮状态圆点
  */
 import React, { useState, useMemo } from 'react';
-import { Layout, Menu, Breadcrumb, Button, Space, Tooltip, theme, message } from 'antd';
+import { Layout, Menu, Breadcrumb, Button, Space, Tooltip, Dropdown, Avatar, theme, message } from 'antd';
 import {
   ExperimentOutlined,
   BlockOutlined,
   MenuFoldOutlined,
   MenuUnfoldOutlined,
   ReloadOutlined,
+  LogoutOutlined,
+  UserOutlined,
 } from '@ant-design/icons';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useApp } from '../store/AppContext';
+import { removeAuth, getUsername } from '../utils/auth';
 import { getStatusConfig } from '../constants';
 
 const { Sider, Header, Content } = Layout;
@@ -227,6 +230,28 @@ export default function AppLayout() {
                 onClick={handleRefresh}
               />
             </Tooltip>
+            <Dropdown trigger={['click']} menu={{
+              items: [
+                {
+                  key: 'logout',
+                  icon: <LogoutOutlined />,
+                  label: '退出登录',
+                  onClick: () => {
+                    removeAuth();
+                    window.location.reload();
+                  },
+                },
+              ],
+            }} placement="bottomRight">
+              <Space style={{ cursor: 'pointer' }}>
+                <Avatar size="small" style={{ background: '#6366f1', fontSize: 13 }}>
+                  {(getUsername() || '?').slice(0, 2).toUpperCase()}
+                </Avatar>
+                <span style={{ fontSize: 13, color: token.colorTextSecondary }}>
+                  {getUsername()}
+                </span>
+              </Space>
+            </Dropdown>
           </Space>
         </Header>
 

--- a/src/routes/Login.jsx
+++ b/src/routes/Login.jsx
@@ -1,0 +1,103 @@
+/**
+ * 登录页
+ * 使用 Basic Auth 验证，凭证存 localStorage
+ */
+import React, { useState } from 'react';
+import { Form, Input, Button, message } from 'antd';
+import { LockOutlined, UserOutlined } from '@ant-design/icons';
+import { setAuth } from '../utils/auth';
+import request from '../utils/request';
+
+export default function Login({ onLogin }) {
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (values) => {
+    setLoading(true);
+    const { username, password } = values;
+
+    // 先保存凭证，再发一个测试请求验证
+    setAuth(username, password);
+    const { err } = await request('/ab/layers');
+
+    if (err) {
+      message.error('用户名或密码错误');
+      setLoading(false);
+      return;
+    }
+
+    message.success('登录成功');
+    onLogin();
+  };
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+    }}>
+      <div style={{
+        width: 380,
+        background: '#fff',
+        borderRadius: 16,
+        padding: '40px 36px',
+        boxShadow: '0 20px 60px rgba(0,0,0,0.15)',
+      }}>
+        <div style={{ textAlign: 'center', marginBottom: 32 }}>
+          <div style={{
+            width: 56,
+            height: 56,
+            borderRadius: 14,
+            background: 'linear-gradient(135deg, #1677ff 0%, #4096ff 100%)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fff',
+            fontSize: 28,
+            fontWeight: 700,
+            marginBottom: 16,
+          }}>
+            A
+          </div>
+          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600, color: '#1f2933' }}>
+            Hawkeye AB
+          </h1>
+          <p style={{ margin: '8px 0 0', color: '#98a2b3', fontSize: 14 }}>
+            A/B 测试管理平台
+          </p>
+        </div>
+
+        <Form onFinish={handleSubmit} size="large">
+          <Form.Item
+            name="username"
+            rules={[{ required: true, message: '请输入用户名' }]}
+          >
+            <Input
+              prefix={<UserOutlined style={{ color: '#98a2b3' }} />}
+              placeholder="用户名"
+              autoComplete="username"
+            />
+          </Form.Item>
+
+          <Form.Item
+            name="password"
+            rules={[{ required: true, message: '请输入密码' }]}
+          >
+            <Input.Password
+              prefix={<LockOutlined style={{ color: '#98a2b3' }} />}
+              placeholder="密码"
+              autoComplete="current-password"
+            />
+          </Form.Item>
+
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Button type="primary" htmlType="submit" block loading={loading}>
+              登录
+            </Button>
+          </Form.Item>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,92 +1,50 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { ConfigProvider, App as AntdApp } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
 import { AppProvider } from '../store/AppContext';
+import { isLoggedIn } from '../utils/auth';
+import Login from './Login';
 import AppLayout from './AppLayout';
 import Experiments from './Experiments';
 import ExperimentDetail from './ExperimentDetail';
 import Layers from './Layers';
 
+/** 路由守卫：未登录跳转到登录页 */
+function RequireAuth({ children }) {
+  if (!isLoggedIn()) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}
+
 function RouterConfig() {
+  const [loggedIn, setLoggedIn] = useState(isLoggedIn());
+
+  if (!loggedIn) {
+    return (
+      <ConfigProvider locale={zhCN}>
+        <AntdApp>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={
+                <Login onLogin={() => setLoggedIn(true)} />
+              } />
+              <Route path="*" element={<Navigate to="/login" replace />} />
+            </Routes>
+          </BrowserRouter>
+        </AntdApp>
+      </ConfigProvider>
+    );
+  }
+
   return (
-    <ConfigProvider
-      locale={zhCN}
-      theme={{
-        token: {
-          colorPrimary: '#6366f1',
-          colorPrimaryHover: '#4f46e5',
-          colorSuccess: '#10b981',
-          colorWarning: '#f59e0b',
-          colorError: '#ef4444',
-          colorInfo: '#3b82f6',
-          colorLink: '#6366f1',
-          colorBgLayout: '#f8fafc',
-          colorText: '#0f172a',
-          colorTextSecondary: '#475569',
-          colorTextTertiary: '#94a3b8',
-          colorBorder: '#e2e8f0',
-          colorBorderSecondary: '#f1f5f9',
-          borderRadius: 10,
-          fontSize: 14,
-          fontFamily:
-            'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif',
-        },
-        components: {
-          Layout: {
-            siderBg: '#ffffff',
-            headerBg: '#ffffff',
-            headerHeight: 60,
-            bodyBg: '#f8fafc',
-          },
-          Menu: {
-            itemSelectedBg: 'rgba(99,102,241,0.10)',
-            itemSelectedColor: '#4f46e5',
-            itemActiveBg: 'rgba(99,102,241,0.06)',
-            itemBorderRadius: 8,
-            itemMarginInline: 10,
-            itemHeight: 40,
-            iconSize: 16,
-          },
-          Card: {
-            borderRadiusLG: 12,
-            defaultBorderColor: '#f1f5f9',
-          },
-          Table: {
-            headerBg: '#f8fafc',
-            headerColor: '#475569',
-            headerSplitColor: 'transparent',
-            rowHoverBg: '#f8fafc',
-            borderColor: '#f1f5f9',
-            cellPaddingBlock: 14,
-          },
-          Button: {
-            borderRadius: 8,
-            controlHeight: 36,
-            controlHeightSM: 30,
-          },
-          Modal: {
-            borderRadiusLG: 14,
-          },
-          Tag: {
-            borderRadiusSM: 6,
-          },
-          Tabs: {
-            inkBarColor: '#6366f1',
-            itemActiveColor: '#4f46e5',
-            itemSelectedColor: '#4f46e5',
-            horizontalItemPadding: '14px 0',
-          },
-          Tooltip: {
-            borderRadius: 8,
-          },
-        },
-      }}
-    >
+    <ConfigProvider locale={zhCN}>
       <AntdApp>
         <AppProvider>
           <BrowserRouter>
             <Routes>
+              <Route path="/login" element={<Navigate to="/" replace />} />
               <Route element={<AppLayout />}>
                 <Route path="/" element={<Experiments />} />
                 <Route path="/experiments/:varName" element={<ExperimentDetail />} />

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,30 @@
+/**
+ * Basic Auth 凭证管理
+ */
+
+const AUTH_KEY = 'ab_auth';
+const USER_KEY = 'ab_user';
+
+export function getAuth() {
+  return localStorage.getItem(AUTH_KEY);
+}
+
+export function getUsername() {
+  return localStorage.getItem(USER_KEY) || '';
+}
+
+export function setAuth(username, password) {
+  const token = btoa(`${username}:${password}`);
+  localStorage.setItem(AUTH_KEY, token);
+  localStorage.setItem(USER_KEY, username);
+  return token;
+}
+
+export function removeAuth() {
+  localStorage.removeItem(AUTH_KEY);
+  localStorage.removeItem(USER_KEY);
+}
+
+export function isLoggedIn() {
+  return !!getAuth();
+}

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,12 +1,19 @@
 /**
- * HTTP 请求工具（精简版，移除了环境切换逻辑）
+ * HTTP 请求工具
+ * 自动携带 Basic Auth 凭证，401 时跳转登录
  */
+import { getAuth, removeAuth } from './auth';
 
 function parseJSON(response) {
   return response.json();
 }
 
 function checkStatus(response) {
+  if (response.status === 401) {
+    removeAuth();
+    window.location.href = '/login';
+    throw new Error('登录已过期，请重新登录');
+  }
   if (response.status >= 200 && response.status < 300) {
     return response;
   }
@@ -20,6 +27,15 @@ export default function request(url, options = {}) {
     ...(options || {}),
     credentials: options.credentials || 'include',
   };
+
+  // 自动带上 Authorization header
+  const token = getAuth();
+  if (token) {
+    newOptions.headers = {
+      ...(newOptions.headers || {}),
+      Authorization: `Basic ${token}`,
+    };
+  }
 
   if (typeof newOptions.body === 'object') {
     newOptions.body = JSON.stringify(newOptions.body);


### PR DESCRIPTION
- 新增 Login.jsx 登录页（Basic Auth 凭证存 localStorage）
- request.js 自动携带 Authorization header，401 跳转登录
- Header 右上角显示用户头像（首字母）+ 退出登录下拉菜单
- HashRouter 改为 BrowserRouter，去掉 URL 中的 #