### PR TITLE
feat(ui): 前端视觉打磨 — 配色统一、骨架屏、空状态与交互优化

### DIFF
--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,0 +1,42 @@
+/**
+ * 自定义空状态
+ * 替代 antd 默认 <Empty>，带图标 + 说明 + 操作引导
+ */
+import React from 'react';
+
+export default function EmptyState({ icon, title, description, action }) {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '60px 24px',
+      textAlign: 'center',
+    }}>
+      <div style={{
+        width: 64,
+        height: 64,
+        borderRadius: 16,
+        background: 'rgba(99, 102, 241, 0.08)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginBottom: 20,
+        color: '#6366f1',
+        fontSize: 28,
+      }}>
+        {icon || '📭'}
+      </div>
+      <h3 style={{ margin: '0 0 8px', fontSize: 16, fontWeight: 600, color: '#0f172a' }}>
+        {title}
+      </h3>
+      {description && (
+        <p style={{ margin: '0 0 20px', color: '#94a3b8', fontSize: 14, maxWidth: 360, lineHeight: 1.6 }}>
+          {description}
+        </p>
+      )}
+      {action}
+    </div>
+  );
+}

--- a/src/components/Skeletons.jsx
+++ b/src/components/Skeletons.jsx
@@ -1,0 +1,68 @@
+/**
+ * 骨架屏组件
+ * 用于页面加载时的占位，匹配最终布局形状
+ */
+import React from 'react';
+import { Skeleton } from 'antd';
+
+/** 实验列表骨架屏 */
+export function ExperimentsSkeleton() {
+  return (
+    <div>
+      {[1, 2].map((i) => (
+        <div
+          key={i}
+          style={{
+            background: '#fff',
+            border: '1px solid #f1f5f9',
+            borderRadius: 12,
+            marginBottom: 14,
+            padding: '20px 20px 4px',
+          }}
+        >
+          <Skeleton
+            active
+            title={{ width: '30%' }}
+            paragraph={{ rows: 1, width: ['15%'] }}
+            style={{ marginBottom: 16 }}
+          />
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(440px, 1fr))', gap: 14, paddingBottom: 16 }}>
+            {[1, 2].map((j) => (
+              <div key={j} style={{ background: '#f8fafc', borderRadius: 12, padding: 18 }}>
+                <Skeleton active title={{ width: '40%' }} paragraph={{ rows: 3, width: ['60%', '80%', '50%'] }} />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** 详情页骨架屏 */
+export function DetailSkeleton() {
+  return (
+    <div style={{ padding: '28px 32px 48px' }}>
+      <Skeleton active title={{ width: '25%' }} paragraph={{ rows: 1, width: ['40%'] }} style={{ marginBottom: 20 }} />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12, marginBottom: 20 }}>
+        {[1, 2, 3].map((i) => (
+          <div key={i} style={{ background: '#fff', border: '1px solid #f1f5f9', borderRadius: 12, padding: 18 }}>
+            <Skeleton active title={{ width: '50%' }} paragraph={{ rows: 1, width: ['70%'] }} />
+          </div>
+        ))}
+      </div>
+      <div style={{ background: '#fff', border: '1px solid #f1f5f9', borderRadius: 12, padding: 24 }}>
+        <Skeleton active title={{ width: '20%' }} paragraph={{ rows: 4, width: ['100%', '100%', '80%', '60%'] }} />
+      </div>
+    </div>
+  );
+}
+
+/** 表格骨架屏 */
+export function TableSkeleton({ rows = 5 }) {
+  return (
+    <div style={{ padding: 24 }}>
+      <Skeleton active title={{ width: '100%' }} paragraph={{ rows, width: Array(rows).fill('100%') }} />
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -283,6 +283,11 @@ ul, ol {
   transform: translateY(-2px);
 }
 
+.exp-card:active {
+  transform: scale(0.985);
+  transition: transform 0.08s ease;
+}
+
 .exp-card:hover::before {
   opacity: 1;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -747,4 +747,13 @@ ul, ol {
   .ant-modal {
     max-width: calc(100vw - 24px) !important;
   }
+
+  .layer-header-bar,
+  .layer-header .ant-progress {
+    display: none !important;
+  }
+
+  .detail-meta-line {
+    gap: 8px;
+  }
 }

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -10,7 +10,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
-  Button, Tabs, Tag, Table, Progress, Space, Empty, Spin, Alert,
+  Button, Tabs, Tag, Table, Progress, Space, Alert, Skeleton,
   Tooltip, Card, Modal, message,
 } from 'antd';
 import {
@@ -26,6 +26,7 @@ import { getStatusConfig, getSignificance } from '../constants';
 import EditWeightModal from '../components/EditWeightModal';
 import NewVersionModal from '../components/NewVersionModal';
 import NewTargetModal from '../components/NewTargetModal';
+import EmptyState from '../components/EmptyState';
 
 // 紧凑数字格式：1234 → 1.2k，1234567 → 1.2M
 function formatCompact(n) {
@@ -104,7 +105,7 @@ export default function ExperimentDetail() {
   if (!test) {
     return (
       <div className="page-container">
-        <Empty description="实验不存在" />
+        <EmptyState icon="🔍" title="实验不存在" />
       </div>
     );
   }
@@ -274,7 +275,7 @@ function OverviewTab({ test, versions, tw, trafficData, trafficLoading }) {
     <div>
       <div className="version-cards">
         {versions.length === 0 ? (
-          <Empty description="暂无版本" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          <EmptyState icon="📦" title="暂无版本" description="点击右上角“新增版本”开始配置" />
         ) : (
           versions.map((v) => {
             const w = tw.weight.find((w) => w.value === v.value);
@@ -301,15 +302,17 @@ function OverviewTab({ test, versions, tw, trafficData, trafficLoading }) {
       </div>
 
       <Card title="流量趋势" size="small" style={{ marginTop: 16, borderRadius: 'var(--radius-lg)' }}>
-        <Spin spinning={trafficLoading}>
-          {trafficData?.error ? (
+        <div style={{ minHeight: trafficLoading ? 320 : 'auto' }}>
+          {trafficLoading ? (
+            <Skeleton active paragraph={{ rows: 6 }} />
+          ) : trafficData?.error ? (
             <Alert type="error" showIcon message={trafficData.error} />
           ) : !trafficData || !trafficData.values || trafficData.values.length === 0 ? (
-            <Empty description="暂无流量数据" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            <EmptyState icon="📈" title="暂无流量数据" description="实验运行后会自动统计流量数据" />
           ) : (
             <TrafficChart trafficData={trafficData} versions={versions} />
           )}
-        </Spin>
+        </div>
       </Card>
     </div>
   );
@@ -351,15 +354,15 @@ function TrafficChart({ trafficData, versions }) {
  * Tab 2: 转化率 —— 版本对比表（带显著性标识）
  * ============================================================ */
 function RateTab({ rateData, rateLoading, defaultValue }) {
-  if (rateLoading) return <Spin />;
-  if (!rateData) return <Empty description="点击此 Tab 加载数据" />;
+  if (rateLoading) return <Skeleton active paragraph={{ rows: 4 }} />;
+  if (!rateData) return <EmptyState icon="📊" title="点击此 Tab 加载转化率数据" />;
   if (rateData.error) return <Alert type="error" showIcon message={rateData.error} />;
 
   const { targets = [], versions: rawVersions = [] } = rateData;
   const rows = parseRateData(rawVersions, targets, defaultValue);
 
   if (rows.length === 0) {
-    return <Empty description="暂无转化率数据" />;
+    return <EmptyState icon="📊" title="暂无转化率数据" />;
   }
 
   const defaultRow = rows.find((r) => r.value === defaultValue) || {};

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -348,6 +348,18 @@ function TrafficChart({ trafficData, versions }) {
       yAxis={{ label: { formatter: (v) => v } }}
       tooltip={{ showCrosshairs: true }}
       color={['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5']}
+      theme={{
+        styleSheet: {
+          brandColor: '#6366f1',
+          paletteQualitative10: ['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5'],
+          backgroundColor: 'transparent',
+        },
+      }}
+      axis={{
+        x: { line: { stroke: '#e2e8f0' }, label: { fill: '#94a3b8' } },
+        y: { line: { stroke: '#e2e8f0' }, label: { fill: '#94a3b8' }, grid: { line: { stroke: '#f1f5f9' } } },
+      }}
+      legend={{ position: 'top', marker: { symbol: 'smooth' } }}
     />
   );
 }

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -191,6 +191,7 @@ export default function ExperimentDetail() {
                 tw={tw}
                 trafficData={trafficData}
                 trafficLoading={trafficLoading}
+                onRetryTraffic={fetchTraffic}
               />
             ),
           },
@@ -202,6 +203,7 @@ export default function ExperimentDetail() {
                 rateData={rateData}
                 rateLoading={rateLoading}
                 defaultValue={test.default_value}
+                onRetry={fetchRate}
               />
             ),
           },
@@ -270,7 +272,7 @@ function KPICard({ label, value, suffix, hint, tone }) {
 /* ============================================================
  * Tab 1: 概览 —— 版本卡片 + 流量趋势图
  * ============================================================ */
-function OverviewTab({ test, versions, tw, trafficData, trafficLoading }) {
+function OverviewTab({ test, versions, tw, trafficData, trafficLoading, onRetryTraffic }) {
   return (
     <div>
       <div className="version-cards">
@@ -306,7 +308,7 @@ function OverviewTab({ test, versions, tw, trafficData, trafficLoading }) {
           {trafficLoading ? (
             <Skeleton active paragraph={{ rows: 6 }} />
           ) : trafficData?.error ? (
-            <Alert type="error" showIcon message={trafficData.error} />
+            <Alert type="error" showIcon message={trafficData.error} action={onRetryTraffic && <Button size="small" onClick={onRetryTraffic}>重试</Button>} />
           ) : !trafficData || !trafficData.values || trafficData.values.length === 0 ? (
             <EmptyState icon="📈" title="暂无流量数据" description="实验运行后会自动统计流量数据" />
           ) : (
@@ -353,10 +355,17 @@ function TrafficChart({ trafficData, versions }) {
 /* ============================================================
  * Tab 2: 转化率 —— 版本对比表（带显著性标识）
  * ============================================================ */
-function RateTab({ rateData, rateLoading, defaultValue }) {
+function RateTab({ rateData, rateLoading, defaultValue, onRetry }) {
   if (rateLoading) return <Skeleton active paragraph={{ rows: 4 }} />;
   if (!rateData) return <EmptyState icon="📊" title="点击此 Tab 加载转化率数据" />;
-  if (rateData.error) return <Alert type="error" showIcon message={rateData.error} />;
+  if (rateData.error) return (
+    <Alert
+      type="error"
+      showIcon
+      message={rateData.error}
+      action={onRetry && <Button size="small" onClick={onRetry}>重试</Button>}
+    />
+  );
 
   const { targets = [], versions: rawVersions = [] } = rateData;
   const rows = parseRateData(rawVersions, targets, defaultValue);

--- a/src/routes/Experiments.jsx
+++ b/src/routes/Experiments.jsx
@@ -7,7 +7,7 @@
 import React, { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  Button, Collapse, Progress, Tag, Space, Tooltip, Empty, Spin, Input, Select,
+  Button, Collapse, Progress, Tag, Space, Tooltip, Input, Select,
   Table, Segmented,
 } from 'antd';
 import {
@@ -19,6 +19,8 @@ import { getStatusConfig } from '../constants';
 import NewTestModal from '../components/NewTestModal';
 import EditWeightModal from '../components/EditWeightModal';
 import NewVersionModal from '../components/NewVersionModal';
+import { ExperimentsSkeleton } from '../components/Skeletons';
+import EmptyState from '../components/EmptyState';
 
 // 状态筛选下拉项
 const STATUS_OPTIONS = [
@@ -120,7 +122,7 @@ export default function Experiments() {
         children: (
           <div className="exp-grid">
             {layerTests.length === 0 ? (
-              <Empty description="该层暂无实验" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+              <EmptyState icon="🔍" title="该层暂无实验" />
             ) : (
               layerTests.map((test) => (
                 <ExperimentCard
@@ -254,16 +256,20 @@ export default function Experiments() {
 
   return (
     <div className="page-container">
-      <Spin spinning={loading}>
-        {!hasData ? (
-          <div className="empty-state">
-            <Empty description="暂无实验数据">
-              <Button type="primary" icon={<PlusOutlined />} onClick={() => openNewTest()}>
-                创建第一个实验
-              </Button>
-            </Empty>
-          </div>
-        ) : (
+      {loading ? (
+        <ExperimentsSkeleton />
+      ) : !hasData ? (
+        <EmptyState
+          icon={<ExperimentOutlined />}
+          title="暂无实验数据"
+          description="创建你的第一个 A/B 测试实验，开始管理版本流量和追踪转化率"
+          action={
+            <Button type="primary" icon={<PlusOutlined />} onClick={() => openNewTest()}>
+              创建第一个实验
+            </Button>
+          }
+        />
+      ) : (
           <>
             {/* ====== 工具栏 ====== */}
             <div className="toolbar">
@@ -314,9 +320,7 @@ export default function Experiments() {
 
             {/* ====== 主体内容 ====== */}
             {filteredTests.length === 0 ? (
-              <div className="empty-state">
-                <Empty description="没有符合筛选条件的实验" image={Empty.PRESENTED_IMAGE_SIMPLE} />
-              </div>
+              <EmptyState icon="🔍" title="没有符合筛选条件的实验" description="调整搜索关键词或状态筛选" />
             ) : view === 'card' ? (
               <Collapse
                 defaultActiveKey={layers.length > 0 ? [layers[0]] : Object.keys(groupedTests)}
@@ -334,7 +338,7 @@ export default function Experiments() {
             )}
           </>
         )}
-      </Spin>
+      )}
 
       <NewTestModal
         open={showNewTest}

--- a/src/routes/Experiments.jsx
+++ b/src/routes/Experiments.jsx
@@ -12,7 +12,7 @@ import {
 } from 'antd';
 import {
   PlusOutlined, PieChartOutlined, PlusCircleOutlined, SearchOutlined,
-  AppstoreOutlined, UnorderedListOutlined,
+  AppstoreOutlined, UnorderedListOutlined, ExperimentOutlined,
 } from '@ant-design/icons';
 import { useApp } from '../store/AppContext';
 import { getStatusConfig } from '../constants';
@@ -338,7 +338,6 @@ export default function Experiments() {
             )}
           </>
         )}
-      )}
 
       <NewTestModal
         open={showNewTest}

--- a/src/routes/Login.jsx
+++ b/src/routes/Login.jsx
@@ -15,7 +15,6 @@ export default function Login({ onLogin }) {
     setLoading(true);
     const { username, password } = values;
 
-    // 先保存凭证，再发一个测试请求验证
     setAuth(username, password);
     const { err } = await request('/ab/layers');
 
@@ -35,21 +34,22 @@ export default function Login({ onLogin }) {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      background: '#f8fafc',
     }}>
       <div style={{
         width: 380,
         background: '#fff',
         borderRadius: 16,
         padding: '40px 36px',
-        boxShadow: '0 20px 60px rgba(0,0,0,0.15)',
+        boxShadow: '0 4px 24px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04)',
+        border: '1px solid #e2e8f0',
       }}>
         <div style={{ textAlign: 'center', marginBottom: 32 }}>
           <div style={{
             width: 56,
             height: 56,
             borderRadius: 14,
-            background: 'linear-gradient(135deg, #1677ff 0%, #4096ff 100%)',
+            background: 'linear-gradient(135deg, #6366f1 0%, #818cf8 100%)',
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -57,13 +57,14 @@ export default function Login({ onLogin }) {
             fontSize: 28,
             fontWeight: 700,
             marginBottom: 16,
+            boxShadow: '0 4px 12px rgba(99, 102, 241, 0.3)',
           }}>
             A
           </div>
-          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600, color: '#1f2933' }}>
+          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em' }}>
             Hawkeye AB
           </h1>
-          <p style={{ margin: '8px 0 0', color: '#98a2b3', fontSize: 14 }}>
+          <p style={{ margin: '8px 0 0', color: '#94a3b8', fontSize: 14 }}>
             A/B 测试管理平台
           </p>
         </div>
@@ -74,7 +75,7 @@ export default function Login({ onLogin }) {
             rules={[{ required: true, message: '请输入用户名' }]}
           >
             <Input
-              prefix={<UserOutlined style={{ color: '#98a2b3' }} />}
+              prefix={<UserOutlined style={{ color: '#94a3b8' }} />}
               placeholder="用户名"
               autoComplete="username"
             />
@@ -85,7 +86,7 @@ export default function Login({ onLogin }) {
             rules={[{ required: true, message: '请输入密码' }]}
           >
             <Input.Password
-              prefix={<LockOutlined style={{ color: '#98a2b3' }} />}
+              prefix={<LockOutlined style={{ color: '#94a3b8' }} />}
               placeholder="密码"
               autoComplete="current-password"
             />

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -10,50 +10,107 @@ import Experiments from './Experiments';
 import ExperimentDetail from './ExperimentDetail';
 import Layers from './Layers';
 
-/** 路由守卫：未登录跳转到登录页 */
-function RequireAuth({ children }) {
-  if (!isLoggedIn()) {
-    return <Navigate to="/login" replace />;
-  }
-  return children;
-}
+const themeConfig = {
+  token: {
+    colorPrimary: '#6366f1',
+    colorPrimaryHover: '#4f46e5',
+    colorSuccess: '#10b981',
+    colorWarning: '#f59e0b',
+    colorError: '#ef4444',
+    colorInfo: '#3b82f6',
+    colorLink: '#6366f1',
+    colorBgLayout: '#f8fafc',
+    colorText: '#0f172a',
+    colorTextSecondary: '#475569',
+    colorTextTertiary: '#94a3b8',
+    colorBorder: '#e2e8f0',
+    colorBorderSecondary: '#f1f5f9',
+    borderRadius: 10,
+    fontSize: 14,
+    fontFamily:
+      'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif',
+  },
+  components: {
+    Layout: {
+      siderBg: '#ffffff',
+      headerBg: '#ffffff',
+      headerHeight: 60,
+      bodyBg: '#f8fafc',
+    },
+    Menu: {
+      itemSelectedBg: 'rgba(99,102,241,0.10)',
+      itemSelectedColor: '#4f46e5',
+      itemActiveBg: 'rgba(99,102,241,0.06)',
+      itemBorderRadius: 8,
+      itemMarginInline: 10,
+      itemHeight: 40,
+      iconSize: 16,
+    },
+    Card: {
+      borderRadiusLG: 12,
+      defaultBorderColor: '#f1f5f9',
+    },
+    Table: {
+      headerBg: '#f8fafc',
+      headerColor: '#475569',
+      headerSplitColor: 'transparent',
+      rowHoverBg: '#f8fafc',
+      borderColor: '#f1f5f9',
+      cellPaddingBlock: 14,
+    },
+    Button: {
+      borderRadius: 8,
+      controlHeight: 36,
+      controlHeightSM: 30,
+    },
+    Modal: {
+      borderRadiusLG: 14,
+    },
+    Tag: {
+      borderRadiusSM: 6,
+    },
+    Tabs: {
+      inkBarColor: '#6366f1',
+      itemActiveColor: '#4f46e5',
+      itemSelectedColor: '#4f46e5',
+      horizontalItemPadding: '14px 0',
+    },
+    Tooltip: {
+      borderRadius: 8,
+    },
+  },
+};
 
 function RouterConfig() {
   const [loggedIn, setLoggedIn] = useState(isLoggedIn());
 
-  if (!loggedIn) {
-    return (
-      <ConfigProvider locale={zhCN}>
-        <AntdApp>
-          <BrowserRouter>
-            <Routes>
-              <Route path="/login" element={
-                <Login onLogin={() => setLoggedIn(true)} />
-              } />
-              <Route path="*" element={<Navigate to="/login" replace />} />
-            </Routes>
-          </BrowserRouter>
-        </AntdApp>
-      </ConfigProvider>
-    );
-  }
+  const content = loggedIn ? (
+    <AppProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Navigate to="/" replace />} />
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Experiments />} />
+            <Route path="/experiments/:varName" element={<ExperimentDetail />} />
+            <Route path="/layers" element={<Layers />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AppProvider>
+  ) : (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<Login onLogin={() => setLoggedIn(true)} />} />
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
 
   return (
-    <ConfigProvider locale={zhCN}>
+    <ConfigProvider locale={zhCN} theme={themeConfig}>
       <AntdApp>
-        <AppProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route path="/login" element={<Navigate to="/" replace />} />
-              <Route element={<AppLayout />}>
-                <Route path="/" element={<Experiments />} />
-                <Route path="/experiments/:varName" element={<ExperimentDetail />} />
-                <Route path="/layers" element={<Layers />} />
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Route>
-            </Routes>
-          </BrowserRouter>
-        </AppProvider>
+        {content}
       </AntdApp>
     </ConfigProvider>
   );


### PR DESCRIPTION
## 概述

基于 design-taste-frontend 审计结果，对前端界面进行系统性打磨，提升视觉一致性和交互体验。

## 改动清单

### 🔴 高优先级
- **登录页配色统一**：去掉紫色渐变（#667eea→#764ba2），改为 Indigo 主题（#6366f1）；ConfigProvider 全局统一，登录页也套用主题 token
- **Skeleton 骨架屏**：新增 `Skeletons.jsx`，实验列表和详情页加载时显示匹配布局形状的骨架屏，替代空白 Spin
- **自定义空状态**：新增 `EmptyState.jsx` 组件，带图标 + 说明 + 操作引导，替代 antd 默认 Empty

###   中优先级
- **卡片触觉反馈**：实验卡片增加 `:active { scale(0.985) }` 模拟物理按压
- **错误状态重试**：转化率 Tab 和流量趋势图的错误状态增加「重试」按钮
- **转化率表格优化**：紧凑布局，主指标突出，次要指标用分隔符收敛

###   低优先级
- **图表主题化**：Line 图表配置 Indigo 配色、网格线、轴标签样式
- **移动端适配**：窄屏隐藏 Layer header 进度条，避免拥挤

## 新增文件
- `src/components/Skeletons.jsx` — 骨架屏组件
- `src/components/EmptyState.jsx` — 自定义空状态组件

## 截图
（部署后补充）