### PR TITLE
feat: 流量分配器组件 + 转化率统计修正 + 数据展示优化

### DIFF
--- a/src/components/EditLayerWeightModal.jsx
+++ b/src/components/EditLayerWeightModal.jsx
@@ -55,6 +55,7 @@ export default function EditLayerWeightModal({ open, layer, onClose }) {
       onCancel={onClose}
       onOk={handleOk}
       destroyOnHidden
+      maskClosable={false}
     >
       {allocatorItems.length > 0 && (
         <TrafficAllocator

--- a/src/components/EditLayerWeightModal.jsx
+++ b/src/components/EditLayerWeightModal.jsx
@@ -1,9 +1,10 @@
 /**
- * 编辑层流量弹窗
+ * 编辑层流量弹窗 —— 使用 TrafficAllocator 组件
  */
 import React, { useState, useEffect } from 'react';
-import { Modal, Slider, message } from 'antd';
+import { Modal, message } from 'antd';
 import { useApp } from '../store/AppContext';
+import TrafficAllocator from './TrafficAllocator';
 
 export default function EditLayerWeightModal({ open, layer, onClose }) {
   const { layerWeight, editLayerWeight } = useApp();
@@ -20,6 +21,12 @@ export default function EditLayerWeightModal({ open, layer, onClose }) {
       setWeights(init);
     }
   }, [open, layer]); // eslint-disable-line
+
+  const allocatorItems = lw.weight.map(({ var_name, name, weight }) => ({
+    key: var_name,
+    label: `${name}(${var_name})`,
+    weight: weights[var_name] ?? weight,
+  }));
 
   const handleOk = async () => {
     const total = Object.values(weights).reduce((s, i) => s + i, 0);
@@ -44,25 +51,17 @@ export default function EditLayerWeightModal({ open, layer, onClose }) {
     <Modal
       title={`编辑 ${layer} 流量`}
       open={open}
-      width={600}
+      width={640}
       onCancel={onClose}
       onOk={handleOk}
       destroyOnHidden
     >
-      {lw.weight.map(({ var_name, name, weight }) => (
-        <div key={var_name} style={{ marginBottom: 40 }}>
-          <div style={{ marginBottom: 8, color: '#667085', fontSize: 13 }}>
-            {name}({var_name})：{weights[var_name] ?? weight}%
-          </div>
-          <Slider
-            min={0}
-            max={100}
-            defaultValue={weight}
-            onChange={(v) => setWeights((prev) => ({ ...prev, [var_name]: v }))}
-            tooltip={{ open: true, formatter: (v) => `${v}%`, getPopupContainer: (n) => n.parentElement }}
-          />
-        </div>
-      ))}
+      {allocatorItems.length > 0 && (
+        <TrafficAllocator
+          items={allocatorItems}
+          onChange={(newWeights) => setWeights(newWeights)}
+        />
+      )}
     </Modal>
   );
 }

--- a/src/components/EditWeightModal.jsx
+++ b/src/components/EditWeightModal.jsx
@@ -62,6 +62,7 @@ export default function EditWeightModal({ open, varName, onClose }) {
       onCancel={onClose}
       onOk={handleOk}
       destroyOnHidden
+      maskClosable={false}
     >
       {allocatorItems.length > 0 && (
         <TrafficAllocator

--- a/src/components/EditWeightModal.jsx
+++ b/src/components/EditWeightModal.jsx
@@ -1,9 +1,10 @@
 /**
- * 编辑版本流量弹窗
+ * 编辑版本流量弹窗 —— 使用 TrafficAllocator 组件
  */
 import React, { useState, useEffect } from 'react';
-import { Modal, Slider, message } from 'antd';
+import { Modal, message } from 'antd';
 import { useApp } from '../store/AppContext';
+import TrafficAllocator from './TrafficAllocator';
 
 export default function EditWeightModal({ open, varName, onClose }) {
   const { testWeight, editVersionWeight } = useApp();
@@ -12,7 +13,6 @@ export default function EditWeightModal({ open, varName, onClose }) {
   const tw = testWeight[varName] || { weight: [], total: 0 };
   const versionWeights = tw.weight;
 
-  // 弹窗打开时初始化
   useEffect(() => {
     if (open && varName) {
       const init = {};
@@ -22,6 +22,13 @@ export default function EditWeightModal({ open, varName, onClose }) {
       setWeights(init);
     }
   }, [open, varName]); // eslint-disable-line
+
+  // 构建分配器 items
+  const allocatorItems = versionWeights.map(({ value, name, weight }) => ({
+    key: value,
+    label: name === value ? value : `${name}(${value})`,
+    weight: weights[value] ?? weight,
+  }));
 
   const handleOk = async () => {
     const total = Object.values(weights).reduce((s, i) => s + i, 0);
@@ -51,25 +58,17 @@ export default function EditWeightModal({ open, varName, onClose }) {
     <Modal
       title="编辑版本流量"
       open={open}
-      width={600}
+      width={640}
       onCancel={onClose}
       onOk={handleOk}
       destroyOnHidden
     >
-      {versionWeights.map(({ value, name, weight }) => (
-        <div key={value} style={{ marginBottom: 40 }}>
-          <div style={{ marginBottom: 8, color: '#667085', fontSize: 13 }}>
-            {name === value ? name : `${name}(${value})`}：{weights[value] ?? weight}%
-          </div>
-          <Slider
-            min={0}
-            max={100}
-            defaultValue={weight}
-            onChange={(v) => setWeights((prev) => ({ ...prev, [value]: v }))}
-            tooltip={{ open: true, formatter: (v) => `${v}%`, getPopupContainer: (n) => n.parentElement }}
-          />
-        </div>
-      ))}
+      {allocatorItems.length > 0 && (
+        <TrafficAllocator
+          items={allocatorItems}
+          onChange={(newWeights) => setWeights(newWeights)}
+        />
+      )}
     </Modal>
   );
 }

--- a/src/components/NewLayerModal.jsx
+++ b/src/components/NewLayerModal.jsx
@@ -33,6 +33,7 @@ export default function NewLayerModal({ open, onClose }) {
       cancelText="取消"
       okButtonProps={{ htmlType: 'submit', form: 'newLayerForm' }}
       destroyOnHidden
+      maskClosable={false}
     >
       <Form id="newLayerForm" form={form} onFinish={handleSubmit}>
         <FormItem

--- a/src/components/NewTargetModal.jsx
+++ b/src/components/NewTargetModal.jsx
@@ -33,6 +33,7 @@ export default function NewTargetModal({ open, varName, onClose }) {
       cancelText="取消"
       okButtonProps={{ htmlType: 'submit', form: 'newTargetForm' }}
       destroyOnHidden
+      maskClosable={false}
     >
       <Form id="newTargetForm" form={form} onFinish={handleSubmit}>
         <FormItem

--- a/src/components/NewTestModal.jsx
+++ b/src/components/NewTestModal.jsx
@@ -45,6 +45,7 @@ export default function NewTestModal({ open, defaultLayer, onClose }) {
       cancelText="取消"
       okButtonProps={{ htmlType: 'submit', form: 'newTestForm' }}
       destroyOnHidden
+      maskClosable={false}
     >
       <Alert
         type="info"

--- a/src/components/NewVersionModal.jsx
+++ b/src/components/NewVersionModal.jsx
@@ -39,6 +39,7 @@ export default function NewVersionModal({ open, experiment, onClose }) {
       cancelText="取消"
       okButtonProps={{ htmlType: 'submit', form: 'newVersionForm' }}
       destroyOnHidden
+      maskClosable={false}
     >
       {remainWeight === 0 && (
         <Alert

--- a/src/components/TrafficAllocator.jsx
+++ b/src/components/TrafficAllocator.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { Slider } from 'antd';
 import { chunk } from '../utils/chunk';
 
-const COLORS = ['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5', '#7c3aed'];
+const COLORS = ['#6366f1', '#10b981', '#f59e0b', '#3b82f6', '#ec4899', '#8b5cf6', '#14b8a6'];
 
 export default function TrafficAllocator({ items, onChange }) {
   const weights = {};

--- a/src/components/TrafficAllocator.jsx
+++ b/src/components/TrafficAllocator.jsx
@@ -1,0 +1,235 @@
+/**
+ * TrafficAllocator - 流量分配器
+ *
+ * 可视化分段拖拽条，用于层流量分配和版本流量分配。
+ * 解决 0% 段 handle 重叠问题：奇偶 handle 交替分布在条的上下方。
+ *
+ * Props:
+ *   items: [{ key, label, weight, color }]
+ *   allowUnallocated: boolean  是否显示"未分配"灰色段
+ *   onChange: (weights: { [key]: number }) => void
+ */
+import React, { useRef, useState, useEffect } from 'react';
+
+const COLORS = ['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5', '#7c3aed'];
+
+export default function TrafficAllocator({
+  items,
+  allowUnallocated = true,
+  onChange,
+}) {
+  const barRef = useRef(null);
+  const [dragIndex, setDragIndex] = useState(null);
+
+  // 计算总流量和未分配
+  const total = items.reduce((s, i) => s + (i.weight || 0), 0);
+  const unallocated = Math.max(0, 100 - total);
+
+  // 构建显示用的段列表（包含未分配段）
+  const segments = items.map((it, i) => ({
+    ...it,
+    color: it.color || COLORS[i % COLORS.length],
+  }));
+  if (allowUnallocated && unallocated > 0) {
+    segments.push({
+      key: '__unallocated',
+      label: '未分配',
+      weight: unallocated,
+      color: '#e2e8f0',
+      unallocated: true,
+    });
+  } else if (allowUnallocated && unallocated === 0) {
+    // 即使没有未分配，也加一个 0 宽度的段用于右边界 handle
+    segments.push({
+      key: '__unallocated',
+      label: '未分配',
+      weight: 0,
+      color: '#e2e8f0',
+      unallocated: true,
+    });
+  }
+
+  // 计算每个段的起止百分比
+  let cursor = 0;
+  const segPositions = segments.map((seg) => {
+    const start = cursor;
+    cursor += seg.weight;
+    return { ...seg, start, end: cursor };
+  });
+
+  // 拖拽逻辑
+  const startDrag = (e, segIdx) => {
+    // segIdx: 正在拖拽 segPositions[segIdx-1] 和 segPositions[segIdx] 之间的边界
+    e.preventDefault();
+    e.stopPropagation();
+    const bar = barRef.current;
+    if (!bar) return;
+    const rect = bar.getBoundingClientRect();
+
+    const onMove = (ev) => {
+      const x = ev.clientX - rect.left;
+      const pct = Math.max(0, Math.min(100, (x / rect.width) * 100));
+
+      // 当前边界位置
+      const leftSeg = segPositions[segIdx - 1];
+      const rightSeg = segPositions[segIdx];
+      if (!leftSeg || !rightSeg) return;
+
+      const oldPos = leftSeg.end;
+      const delta = pct - oldPos;
+      if (Math.abs(delta) < 0.1) return;
+
+      // 构建新的权重数组（副本）
+      const newItems = items.map((it) => ({ ...it }));
+
+      // 找到对应的 items 索引（排除 unallocated）
+      // segIdx 是 segments 数组的索引，需要映射回 items
+      // segments[0..items.length-1] = items, segments[items.length] = unallocated
+      const leftItemIdx = segIdx - 1;
+      const rightItemIdx = segIdx;
+
+      if (delta > 0) {
+        // 向右拖：左边增大，右边减小
+        const leftCanGrow = leftSeg.unallocated ? 0 : (100 - (newItems[leftItemIdx]?.weight || 0));
+        const rightCanShrink = rightSeg.unallocated ? rightSeg.weight : (newItems[rightItemIdx]?.weight || 0);
+        const actual = Math.min(delta, leftCanGrow, rightCanShrink);
+        if (actual <= 0) return;
+
+        if (!leftSeg.unallocated && newItems[leftItemIdx]) {
+          newItems[leftItemIdx].weight = Math.round((newItems[leftItemIdx].weight + actual) * 10) / 10;
+        }
+        if (!rightSeg.unallocated && newItems[rightItemIdx]) {
+          newItems[rightItemIdx].weight = Math.round((newItems[rightItemIdx].weight - actual) * 10) / 10;
+        }
+      } else {
+        // 向左拖：左边减小，右边增大
+        const leftCanShrink = leftSeg.unallocated ? 0 : (newItems[leftItemIdx]?.weight || 0);
+        const rightCanGrow = rightSeg.unallocated ? 0 : (100 - (newItems[rightItemIdx]?.weight || 0));
+        const actual = Math.min(-delta, leftCanShrink, rightCanGrow);
+        if (actual <= 0) return;
+
+        if (!leftSeg.unallocated && newItems[leftItemIdx]) {
+          newItems[leftItemIdx].weight = Math.round((newItems[leftItemIdx].weight - actual) * 10) / 10;
+        }
+        if (!rightSeg.unallocated && newItems[rightItemIdx]) {
+          newItems[rightItemIdx].weight = Math.round((newItems[rightItemIdx].weight + actual) * 10) / 10;
+        }
+      }
+
+      const weights = {};
+      newItems.forEach((it) => { weights[it.key] = it.weight; });
+      onChange(weights);
+    };
+
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      setDragIndex(null);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    setDragIndex(segIdx);
+  };
+
+  // 可拖拽的边界（排除最左 0% 和最右 100%）
+  const draggables = [];
+  for (let i = 1; i < segPositions.length; i++) {
+    const left = segPositions[i - 1];
+    const right = segPositions[i];
+    // 如果左右都是 unallocated，跳过
+    if (left.unallocated && right.unallocated) continue;
+    draggables.push({
+      index: i,
+      pos: right.start, // 百分比位置
+      onTop: i % 2 === 1, // 奇数在上，偶数在下
+      leftSeg: left,
+      rightSeg: right,
+    });
+  }
+
+  return (
+    <div className="traffic-allocator">
+      {/* 拖拽条 */}
+      <div className="ta-bar-wrapper" ref={barRef}>
+        {/* 分段条 */}
+        <div className="ta-bar">
+          {segPositions.map((seg) => {
+            const width = seg.end - seg.start;
+            if (width <= 0 && !seg.unallocated) return null;
+            return (
+              <div
+                key={seg.key}
+                className={`ta-segment ${seg.unallocated ? 'ta-segment-unallocated' : ''}`}
+                style={{
+                  width: `${width}%`,
+                  background: seg.color,
+                  minWidth: width > 0 ? undefined : 0,
+                }}
+                title={`${seg.label}: ${seg.weight}%`}
+              >
+                {width >= 8 && (
+                  <span className="ta-segment-label">{seg.weight}%</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 拖拽 handle */}
+        {draggables.map((d) => {
+          const isLeftUnalloc = d.leftSeg.unallocated;
+          const isRightUnalloc = d.rightSeg.unallocated;
+          // 如果其中一段是 unallocated 且为 0 宽度，仍可拖
+          return (
+            <div
+              key={d.index}
+              className={`ta-handle ${d.onTop ? 'ta-handle-top' : 'ta-handle-bottom'} ${dragIndex === d.index ? 'ta-handle-active' : ''}`}
+              style={{ left: `${d.pos}%` }}
+              onMouseDown={(e) => startDrag(e, d.index)}
+            >
+              <div className="ta-handle-grip" />
+              <div className="ta-handle-line" />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 各段信息 */}
+      <div className="ta-legend">
+        {items.map((it, i) => {
+          const color = COLORS[i % COLORS.length];
+          return (
+            <div key={it.key} className="ta-legend-item">
+              <span className="ta-legend-dot" style={{ background: color }} />
+              <span className="ta-legend-label">{it.label}</span>
+              <input
+                type="number"
+                className="ta-legend-input"
+                min={0}
+                max={100}
+                value={it.weight}
+                onChange={(e) => {
+                  const val = Math.max(0, Math.min(100, Number(e.target.value) || 0));
+                  onChange({ ...items.reduce((acc, cur) => ({ ...acc, [cur.key]: cur.weight }), {}), [it.key]: val });
+                }}
+              />
+              <span className="ta-legend-percent">%</span>
+            </div>
+          );
+        })}
+        {allowUnallocated && (
+          <div className="ta-legend-item ta-legend-unallocated">
+            <span className="ta-legend-dot" style={{ background: '#e2e8f0' }} />
+            <span className="ta-legend-label">未分配</span>
+            <span className="ta-legend-value">{unallocated}%</span>
+          </div>
+        )}
+        <div className="ta-legend-total">
+          合计：<strong className={total > 100 ? 'ta-total-over' : ''}>{total}%</strong>
+          {total < 100 && allowUnallocated && <span className="ta-total-remain">（剩余 {100 - total}%）</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TrafficAllocator.jsx
+++ b/src/components/TrafficAllocator.jsx
@@ -1,234 +1,83 @@
 /**
  * TrafficAllocator - 流量分配器
  *
- * 可视化分段拖拽条，用于层流量分配和版本流量分配。
- * 解决 0% 段 handle 重叠问题：奇偶 handle 交替分布在条的上下方。
+ * 基于 antd Slider，每个段的 max 动态计算为 100 - 其他段总和，
+ * 天然防止总量超过 100%，无需额外约束逻辑。
  *
  * Props:
- *   items: [{ key, label, weight, color }]
- *   allowUnallocated: boolean  是否显示"未分配"灰色段
+ *   items: [{ key, label, weight }]
  *   onChange: (weights: { [key]: number }) => void
  */
-import React, { useRef, useState, useEffect } from 'react';
+import React from 'react';
+import { Slider } from 'antd';
+import { chunk } from '../utils/chunk';
 
 const COLORS = ['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5', '#7c3aed'];
 
-export default function TrafficAllocator({
-  items,
-  allowUnallocated = true,
-  onChange,
-}) {
-  const barRef = useRef(null);
-  const [dragIndex, setDragIndex] = useState(null);
+export default function TrafficAllocator({ items, onChange }) {
+  const weights = {};
+  items.forEach((it) => { weights[it.key] = it.weight; });
 
-  // 计算总流量和未分配
-  const total = items.reduce((s, i) => s + (i.weight || 0), 0);
+  const total = items.reduce((s, it) => s + it.weight, 0);
   const unallocated = Math.max(0, 100 - total);
 
-  // 构建显示用的段列表（包含未分配段）
-  const segments = items.map((it, i) => ({
-    ...it,
-    color: it.color || COLORS[i % COLORS.length],
-  }));
-  if (allowUnallocated && unallocated > 0) {
-    segments.push({
-      key: '__unallocated',
-      label: '未分配',
-      weight: unallocated,
-      color: '#e2e8f0',
-      unallocated: true,
-    });
-  } else if (allowUnallocated && unallocated === 0) {
-    // 即使没有未分配，也加一个 0 宽度的段用于右边界 handle
-    segments.push({
-      key: '__unallocated',
-      label: '未分配',
-      weight: 0,
-      color: '#e2e8f0',
-      unallocated: true,
-    });
-  }
-
-  // 计算每个段的起止百分比
-  let cursor = 0;
-  const segPositions = segments.map((seg) => {
-    const start = cursor;
-    cursor += seg.weight;
-    return { ...seg, start, end: cursor };
-  });
-
-  // 拖拽逻辑
-  const startDrag = (e, segIdx) => {
-    // segIdx: 正在拖拽 segPositions[segIdx-1] 和 segPositions[segIdx] 之间的边界
-    e.preventDefault();
-    e.stopPropagation();
-    const bar = barRef.current;
-    if (!bar) return;
-    const rect = bar.getBoundingClientRect();
-
-    const onMove = (ev) => {
-      const x = ev.clientX - rect.left;
-      const pct = Math.max(0, Math.min(100, (x / rect.width) * 100));
-
-      // 当前边界位置
-      const leftSeg = segPositions[segIdx - 1];
-      const rightSeg = segPositions[segIdx];
-      if (!leftSeg || !rightSeg) return;
-
-      const oldPos = leftSeg.end;
-      const delta = pct - oldPos;
-      if (Math.abs(delta) < 0.1) return;
-
-      // 构建新的权重数组（副本）
-      const newItems = items.map((it) => ({ ...it }));
-
-      // 找到对应的 items 索引（排除 unallocated）
-      // segIdx 是 segments 数组的索引，需要映射回 items
-      // segments[0..items.length-1] = items, segments[items.length] = unallocated
-      const leftItemIdx = segIdx - 1;
-      const rightItemIdx = segIdx;
-
-      if (delta > 0) {
-        // 向右拖：左边增大，右边减小
-        const leftCanGrow = leftSeg.unallocated ? 0 : (100 - (newItems[leftItemIdx]?.weight || 0));
-        const rightCanShrink = rightSeg.unallocated ? rightSeg.weight : (newItems[rightItemIdx]?.weight || 0);
-        const actual = Math.min(delta, leftCanGrow, rightCanShrink);
-        if (actual <= 0) return;
-
-        if (!leftSeg.unallocated && newItems[leftItemIdx]) {
-          newItems[leftItemIdx].weight = Math.round((newItems[leftItemIdx].weight + actual) * 10) / 10;
-        }
-        if (!rightSeg.unallocated && newItems[rightItemIdx]) {
-          newItems[rightItemIdx].weight = Math.round((newItems[rightItemIdx].weight - actual) * 10) / 10;
-        }
-      } else {
-        // 向左拖：左边减小，右边增大
-        const leftCanShrink = leftSeg.unallocated ? 0 : (newItems[leftItemIdx]?.weight || 0);
-        const rightCanGrow = rightSeg.unallocated ? 0 : (100 - (newItems[rightItemIdx]?.weight || 0));
-        const actual = Math.min(-delta, leftCanShrink, rightCanGrow);
-        if (actual <= 0) return;
-
-        if (!leftSeg.unallocated && newItems[leftItemIdx]) {
-          newItems[leftItemIdx].weight = Math.round((newItems[leftItemIdx].weight - actual) * 10) / 10;
-        }
-        if (!rightSeg.unallocated && newItems[rightItemIdx]) {
-          newItems[rightItemIdx].weight = Math.round((newItems[rightItemIdx].weight + actual) * 10) / 10;
-        }
-      }
-
-      const weights = {};
-      newItems.forEach((it) => { weights[it.key] = it.weight; });
-      onChange(weights);
-    };
-
-    const onUp = () => {
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', onUp);
-      setDragIndex(null);
-    };
-
-    document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', onUp);
-    setDragIndex(segIdx);
+  const handleChange = (key, val) => {
+    onChange({ ...weights, [key]: val });
   };
-
-  // 可拖拽的边界（排除最左 0% 和最右 100%）
-  const draggables = [];
-  for (let i = 1; i < segPositions.length; i++) {
-    const left = segPositions[i - 1];
-    const right = segPositions[i];
-    // 如果左右都是 unallocated，跳过
-    if (left.unallocated && right.unallocated) continue;
-    draggables.push({
-      index: i,
-      pos: right.start, // 百分比位置
-      onTop: i % 2 === 1, // 奇数在上，偶数在下
-      leftSeg: left,
-      rightSeg: right,
-    });
-  }
 
   return (
     <div className="traffic-allocator">
-      {/* 拖拽条 */}
-      <div className="ta-bar-wrapper" ref={barRef}>
-        {/* 分段条 */}
-        <div className="ta-bar">
-          {segPositions.map((seg) => {
-            const width = seg.end - seg.start;
-            if (width <= 0 && !seg.unallocated) return null;
-            return (
-              <div
-                key={seg.key}
-                className={`ta-segment ${seg.unallocated ? 'ta-segment-unallocated' : ''}`}
-                style={{
-                  width: `${width}%`,
-                  background: seg.color,
-                  minWidth: width > 0 ? undefined : 0,
-                }}
-                title={`${seg.label}: ${seg.weight}%`}
-              >
-                {width >= 8 && (
-                  <span className="ta-segment-label">{seg.weight}%</span>
-                )}
-              </div>
-            );
-          })}
-        </div>
-
-        {/* 拖拽 handle */}
-        {draggables.map((d) => {
-          const isLeftUnalloc = d.leftSeg.unallocated;
-          const isRightUnalloc = d.rightSeg.unallocated;
-          // 如果其中一段是 unallocated 且为 0 宽度，仍可拖
-          return (
+      {/* 总览条 */}
+      <div className="ta-overview">
+        <div className="ta-overview-bar">
+          {items.map((it, i) => (
             <div
-              key={d.index}
-              className={`ta-handle ${d.onTop ? 'ta-handle-top' : 'ta-handle-bottom'} ${dragIndex === d.index ? 'ta-handle-active' : ''}`}
-              style={{ left: `${d.pos}%` }}
-              onMouseDown={(e) => startDrag(e, d.index)}
-            >
-              <div className="ta-handle-grip" />
-              <div className="ta-handle-line" />
-            </div>
-          );
-        })}
+              key={it.key}
+              className="ta-overview-seg"
+              style={{
+                width: `${it.weight}%`,
+                background: COLORS[i % COLORS.length],
+              }}
+            />
+          ))}
+          {unallocated > 0 && (
+            <div
+              className="ta-overview-seg ta-overview-unallocated"
+              style={{ width: `${unallocated}%` }}
+            />
+          )}
+        </div>
+        <div className="ta-overview-info">
+          <span>合计 <strong>{total}%</strong></span>
+          {unallocated > 0 && <span className="ta-overview-remain">未分配 {unallocated}%</span>}
+        </div>
       </div>
 
-      {/* 各段信息 */}
-      <div className="ta-legend">
+      {/* 各段 slider */}
+      <div className="ta-sliders">
         {items.map((it, i) => {
-          const color = COLORS[i % COLORS.length];
+          // 关键：max = 100 - 其他所有段的总和
+          const othersSum = total - it.weight;
+          const maxForThis = 100 - othersSum;
+
           return (
-            <div key={it.key} className="ta-legend-item">
-              <span className="ta-legend-dot" style={{ background: color }} />
-              <span className="ta-legend-label">{it.label}</span>
-              <input
-                type="number"
-                className="ta-legend-input"
+            <div key={it.key} className="ta-slider-row">
+              <div className="ta-slider-header">
+                <span className="ta-slider-dot" style={{ background: COLORS[i % COLORS.length] }} />
+                <span className="ta-slider-label">{it.label}</span>
+                <span className="ta-slider-value">{it.weight}%</span>
+              </div>
+              <Slider
                 min={0}
-                max={100}
+                max={maxForThis}
                 value={it.weight}
-                onChange={(e) => {
-                  const val = Math.max(0, Math.min(100, Number(e.target.value) || 0));
-                  onChange({ ...items.reduce((acc, cur) => ({ ...acc, [cur.key]: cur.weight }), {}), [it.key]: val });
-                }}
+                onChange={(v) => handleChange(it.key, v)}
+                tooltip={{ formatter: (v) => `${v}%` }}
+                style={{ margin: '0 2px' }}
               />
-              <span className="ta-legend-percent">%</span>
             </div>
           );
         })}
-        {allowUnallocated && (
-          <div className="ta-legend-item ta-legend-unallocated">
-            <span className="ta-legend-dot" style={{ background: '#e2e8f0' }} />
-            <span className="ta-legend-label">未分配</span>
-            <span className="ta-legend-value">{unallocated}%</span>
-          </div>
-        )}
-        <div className="ta-legend-total">
-          合计：<strong className={total > 100 ? 'ta-total-over' : ''}>{total}%</strong>
-          {total < 100 && allowUnallocated && <span className="ta-total-remain">（剩余 {100 - total}%）</span>}
-        </div>
       </div>
     </div>
   );

--- a/src/components/TrafficAllocator.jsx
+++ b/src/components/TrafficAllocator.jsx
@@ -69,9 +69,9 @@ export default function TrafficAllocator({ items, onChange }) {
               </div>
               <Slider
                 min={0}
-                max={maxForThis}
+                max={100}
                 value={it.weight}
-                onChange={(v) => handleChange(it.key, v)}
+                onChange={(v) => handleChange(it.key, Math.min(v, maxForThis))}
                 tooltip={{ formatter: (v) => `${v}%` }}
                 style={{ margin: '0 2px' }}
               />

--- a/src/components/TrafficBar.jsx
+++ b/src/components/TrafficBar.jsx
@@ -1,0 +1,51 @@
+/**
+ * TrafficBar - 流量分配迷你条
+ * 展示各段占比 + 未分配斜纹段，用于表格、卡片等紧凑场景
+ *
+ * Props:
+ *   segments: [{ label?, weight, color? }]  各段权重
+ *   showLabel: boolean  是否在条上显示百分比
+ *   height: number  条高度
+ */
+import React from 'react';
+
+const COLORS = ['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5', '#7c3aed', '#6366f1'];
+
+export default function TrafficBar({ segments = [], height = 24, showLabel = false }) {
+  const total = segments.reduce((s, seg) => s + (seg.weight || 0), 0);
+  const unallocated = Math.max(0, 100 - total);
+
+  return (
+    <div className="traffic-bar" style={{ height }}>
+      {segments.map((seg, i) => {
+        if (!seg.weight) return null;
+        return (
+          <div
+            key={i}
+            className="traffic-bar-seg"
+            style={{
+              width: `${seg.weight}%`,
+              background: seg.color || COLORS[i % COLORS.length],
+            }}
+            title={seg.label ? `${seg.label}: ${seg.weight}%` : `${seg.weight}%`}
+          >
+            {showLabel && seg.weight >= 8 && (
+              <span className="traffic-bar-label">{seg.weight}%</span>
+            )}
+          </div>
+        );
+      })}
+      {unallocated > 0 && (
+        <div
+          className="traffic-bar-seg traffic-bar-unallocated"
+          style={{ width: `${unallocated}%` }}
+          title={`未分配: ${unallocated}%`}
+        >
+          {showLabel && unallocated >= 8 && (
+            <span className="traffic-bar-label traffic-bar-label-muted">{unallocated}%</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TrafficBar.jsx
+++ b/src/components/TrafficBar.jsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 
-const COLORS = ['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5', '#7c3aed', '#6366f1'];
+const COLORS = ['#6366f1', '#10b981', '#f59e0b', '#3b82f6', '#ec4899', '#8b5cf6', '#14b8a6'];
 
 export default function TrafficBar({ segments = [], height = 24, showLabel = false }) {
   const total = segments.reduce((s, seg) => s + (seg.weight || 0), 0);

--- a/src/index.css
+++ b/src/index.css
@@ -655,6 +655,7 @@ ul, ol {
 
 .rate-line {
   color: var(--text-2);
+  white-space: nowrap;
 }
 
 .rate-line-muted {

--- a/src/index.css
+++ b/src/index.css
@@ -726,6 +726,186 @@ ul, ol {
   text-transform: uppercase;
 }
 
+/* ==================== 流量分配器 ==================== */
+.traffic-allocator {
+  padding: 8px 0;
+}
+
+.ta-bar-wrapper {
+  position: relative;
+  height: 72px;
+  padding: 24px 0;
+  margin-bottom: 20px;
+  user-select: none;
+}
+
+.ta-bar {
+  display: flex;
+  height: 24px;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.06);
+  background: #f1f5f9;
+}
+
+.ta-segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  transition: width 0.05s linear;
+  position: relative;
+  min-width: 0;
+}
+
+.ta-segment-unallocated {
+  background: #e2e8f0 !important;
+  color: #94a3b8;
+}
+
+.ta-segment-label {
+  text-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+/* Handle: 奇偶交替上下 */
+.ta-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  cursor: ew-resize;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.ta-handle-grip {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--brand, #6366f1);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+  flex-shrink: 0;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+  cursor: ew-resize;
+}
+
+.ta-handle:hover .ta-handle-grip {
+  transform: scale(1.25);
+  box-shadow: 0 2px 8px rgba(99,102,241,0.3);
+}
+
+.ta-handle-active .ta-handle-grip {
+  transform: scale(1.3);
+  box-shadow: 0 2px 8px rgba(99,102,241,0.4);
+  background: var(--brand, #6366f1);
+}
+
+.ta-handle-line {
+  width: 2px;
+  flex: 1;
+  background: var(--brand, #6366f1);
+  opacity: 0.4;
+  border-radius: 1px;
+  transition: opacity 0.12s ease;
+}
+
+.ta-handle:hover .ta-handle-line,
+.ta-handle-active .ta-handle-line {
+  opacity: 0.8;
+}
+
+/* 奇数 handle: grip 在上方 */
+.ta-handle-top {
+  justify-content: flex-start;
+}
+
+/* 偶数 handle: grip 在下方 */
+.ta-handle-bottom {
+  justify-content: flex-end;
+}
+
+/* 图例 + 输入 */
+.ta-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  align-items: center;
+}
+
+.ta-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.ta-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.ta-legend-label {
+  color: var(--text-2, #475569);
+  font-weight: 500;
+}
+
+.ta-legend-input {
+  width: 48px;
+  padding: 2px 6px;
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 6px;
+  font-size: 13px;
+  text-align: center;
+  color: var(--text-1, #0f172a);
+  font-variant-numeric: tabular-nums;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.ta-legend-input:focus {
+  border-color: var(--brand, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99,102,241,0.1);
+}
+
+.ta-legend-percent {
+  color: var(--text-3, #94a3b8);
+  font-size: 12px;
+}
+
+.ta-legend-unallocated {
+  color: var(--text-3, #94a3b8);
+}
+
+.ta-legend-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.ta-legend-total {
+  margin-left: auto;
+  font-size: 13px;
+  color: var(--text-2, #475569);
+}
+
+.ta-total-over {
+  color: var(--danger, #ef4444);
+}
+
+.ta-total-remain {
+  color: var(--text-3, #94a3b8);
+  font-size: 12px;
+}
+
 /* ==================== 响应式 ==================== */
 @media (max-width: 768px) {
   .page-container {

--- a/src/index.css
+++ b/src/index.css
@@ -726,6 +726,43 @@ ul, ol {
   text-transform: uppercase;
 }
 
+/* ==================== 迷你流量条 ==================== */
+.traffic-bar {
+  display: flex;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #f1f5f9;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.06);
+}
+
+.traffic-bar-seg {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  transition: width 0.15s ease;
+}
+
+.traffic-bar-unallocated {
+  background-image: repeating-linear-gradient(
+    45deg, #e2e8f0, #e2e8f0 4px, #eef2f7 4px, #eef2f7 8px
+  );
+}
+
+.traffic-bar-label {
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.25);
+  white-space: nowrap;
+}
+
+.traffic-bar-label-muted {
+  color: #94a3b8;
+  text-shadow: none;
+}
+
 /* ==================== 流量分配器 ==================== */
 .traffic-allocator {
   padding: 4px 0;

--- a/src/index.css
+++ b/src/index.css
@@ -728,182 +728,91 @@ ul, ol {
 
 /* ==================== 流量分配器 ==================== */
 .traffic-allocator {
-  padding: 8px 0;
+  padding: 4px 0;
 }
 
-.ta-bar-wrapper {
-  position: relative;
-  height: 72px;
-  padding: 24px 0;
-  margin-bottom: 20px;
-  user-select: none;
+/* 总览条 */
+.ta-overview {
+  margin-bottom: 24px;
 }
 
-.ta-bar {
+.ta-overview-bar {
   display: flex;
-  height: 24px;
-  border-radius: 6px;
+  height: 28px;
+  border-radius: 8px;
   overflow: hidden;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.06);
   background: #f1f5f9;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.06);
 }
 
-.ta-segment {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.ta-overview-seg {
   height: 100%;
-  color: #fff;
-  font-size: 11px;
-  font-weight: 600;
-  transition: width 0.05s linear;
-  position: relative;
+  transition: width 0.15s ease;
   min-width: 0;
 }
 
-.ta-segment-unallocated {
-  background: #e2e8f0 !important;
+.ta-overview-unallocated {
+  background: #e2e8f0;
+  background-image: repeating-linear-gradient(
+    45deg, #e2e8f0, #e2e8f0 6px, #eef2f7 6px, #eef2f7 12px
+  );
+}
+
+.ta-overview-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.ta-overview-info strong {
+  color: #0f172a;
+  font-variant-numeric: tabular-nums;
+}
+
+.ta-overview-remain {
   color: #94a3b8;
 }
 
-.ta-segment-label {
-  text-shadow: 0 1px 2px rgba(0,0,0,0.2);
-  pointer-events: none;
-  white-space: nowrap;
-}
-
-/* Handle: 奇偶交替上下 */
-.ta-handle {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 0;
-  cursor: ew-resize;
-  z-index: 10;
+/* 各段 slider */
+.ta-sliders {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  gap: 20px;
 }
 
-.ta-handle-grip {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: #fff;
-  border: 2px solid var(--brand, #6366f1);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
-  flex-shrink: 0;
-  transition: transform 0.12s ease, box-shadow 0.12s ease;
-  cursor: ew-resize;
+.ta-slider-row {
+  padding: 0 2px;
 }
 
-.ta-handle:hover .ta-handle-grip {
-  transform: scale(1.25);
-  box-shadow: 0 2px 8px rgba(99,102,241,0.3);
-}
-
-.ta-handle-active .ta-handle-grip {
-  transform: scale(1.3);
-  box-shadow: 0 2px 8px rgba(99,102,241,0.4);
-  background: var(--brand, #6366f1);
-}
-
-.ta-handle-line {
-  width: 2px;
-  flex: 1;
-  background: var(--brand, #6366f1);
-  opacity: 0.4;
-  border-radius: 1px;
-  transition: opacity 0.12s ease;
-}
-
-.ta-handle:hover .ta-handle-line,
-.ta-handle-active .ta-handle-line {
-  opacity: 0.8;
-}
-
-/* 奇数 handle: grip 在上方 */
-.ta-handle-top {
-  justify-content: flex-start;
-}
-
-/* 偶数 handle: grip 在下方 */
-.ta-handle-bottom {
-  justify-content: flex-end;
-}
-
-/* 图例 + 输入 */
-.ta-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 20px;
-  align-items: center;
-}
-
-.ta-legend-item {
+.ta-slider-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 13px;
+  gap: 8px;
+  margin-bottom: 4px;
 }
 
-.ta-legend-dot {
+.ta-slider-dot {
   width: 10px;
   height: 10px;
   border-radius: 3px;
   flex-shrink: 0;
 }
 
-.ta-legend-label {
-  color: var(--text-2, #475569);
-  font-weight: 500;
-}
-
-.ta-legend-input {
-  width: 48px;
-  padding: 2px 6px;
-  border: 1px solid var(--border, #e2e8f0);
-  border-radius: 6px;
+.ta-slider-label {
   font-size: 13px;
-  text-align: center;
-  color: var(--text-1, #0f172a);
-  font-variant-numeric: tabular-nums;
-  outline: none;
-  transition: border-color 0.15s ease;
-}
-
-.ta-legend-input:focus {
-  border-color: var(--brand, #6366f1);
-  box-shadow: 0 0 0 2px rgba(99,102,241,0.1);
-}
-
-.ta-legend-percent {
-  color: var(--text-3, #94a3b8);
-  font-size: 12px;
-}
-
-.ta-legend-unallocated {
-  color: var(--text-3, #94a3b8);
-}
-
-.ta-legend-value {
-  font-variant-numeric: tabular-nums;
+  color: #475569;
   font-weight: 500;
 }
 
-.ta-legend-total {
+.ta-slider-value {
   margin-left: auto;
-  font-size: 13px;
-  color: var(--text-2, #475569);
-}
-
-.ta-total-over {
-  color: var(--danger, #ef4444);
-}
-
-.ta-total-remain {
-  color: var(--text-3, #94a3b8);
-  font-size: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  font-variant-numeric: tabular-nums;
 }
 
 /* ==================== 响应式 ==================== */

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -443,7 +443,9 @@ function RateTab({ rateData, rateLoading, defaultValue, onRetry }) {
               转化率：转化人数／实验UV<br />
               转化人数：累计指标触发人数<br />
               总值：累计上报指标数<br />
-              均值：指标总值／实验UV<br />
+              人均：总值／转化人数<br />
+              全量均值：总值／实验UV（含未转化用户，用于 Z 检验）<br />
+              标准差：全量均值的离散程度<br />
               lift：相对对照组转化率的提升幅度
             </div>
           }
@@ -490,7 +492,12 @@ function RateTab({ rateData, rateLoading, defaultValue, onRetry }) {
               <SignificanceBadge sig={sig} />
             </div>
             <div className="rate-line">转化人数：<b>{t.user || 0}</b></div>
-            <div className="rate-line rate-line-muted">总值：{t.count || 0} · 人均：{(t.user ? (t.count / t.user).toFixed(2) : '-')}</div>
+            <div className="rate-line rate-line-muted">
+                总值：{t.count || 0} · 人均：{t.user ? (t.count / t.user).toFixed(2) : '-'}
+              </div>
+              <div className="rate-line rate-line-muted">
+                全量均值：{tRealMean.toFixed(2)} · 标准差：{tRealStd.toFixed(3)}
+              </div>
             {row.value !== defaultValue && (
               <div className="rate-line rate-line-muted" style={{ marginTop: 2 }}>
                 Z: {isNaN(zscore) ? '-' : zscore.toFixed(3)} · p: {isNaN(pvalue) ? '-' : pvalue.toFixed(3)}

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -21,7 +21,7 @@ import {
 import { Line } from '@ant-design/plots';
 import { useApp } from '../store/AppContext';
 import { parseRateData, parseTrafficData } from '../utils/parse';
-import { getZPercent, ZScore, realMeanStd } from '../utils/stats';
+import { getZPercent, ZScore, realMeanStd, proportionZTest } from '../utils/stats';
 import { getStatusConfig, getSignificance } from '../constants';
 import EditWeightModal from '../components/EditWeightModal';
 import NewVersionModal from '../components/NewVersionModal';

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -225,6 +225,8 @@ export default function ExperimentDetail() {
             children: (
               <TargetsTab
                 targets={testTargets}
+                rateData={rateData}
+                defaultValue={test.default_value}
                 onAddTarget={() => setShowNewTarget(true)}
               />
             ),
@@ -601,27 +603,60 @@ function VersionsTab({ versions, tw, onEditWeight, onAddVersion }) {
 /* ============================================================
  * Tab 4: 指标管理
  * ============================================================ */
-function TargetsTab({ targets, onAddTarget }) {
+function TargetsTab({ targets, rateData, defaultValue, onAddTarget }) {
+  // aggregate from rate data
+  const aggMap = React.useMemo(() => {
+    if (!rateData || rateData.error) return {};
+    const { targets: rateTargets = [], versions: rawVersions = [] } = rateData;
+    const rows = parseRateData(rawVersions, rateTargets, defaultValue);
+    const map = {};
+    let totalUV = 0;
+    for (const row of rows) totalUV += row.uv || 0;
+    for (const tName of rateTargets) {
+      let count = 0, user = 0;
+      for (const row of rows) {
+        const t = row.targets[tName];
+        if (t) { count += t.count || 0; user += t.user || 0; }
+      }
+      map[tName] = { count, user, rate: totalUV > 0 ? (user / totalUV) * 100 : 0 };
+    }
+    return map;
+  }, [rateData, defaultValue]);
+
   const columns = [
     {
       title: '指标名称', dataIndex: 'target_name', key: 'target_name',
       render: (v) => <span style={{ fontFamily: '"SF Mono", monospace', fontSize: 13 }}>{v}</span>,
     },
     {
-      title: '触发次数',
-      dataIndex: 'count',
+      title: '触发总量',
       key: 'count',
       align: 'right',
-      render: (v) => <span style={{ fontVariantNumeric: 'tabular-nums' }}>{v || '-'}</span>,
+      render: (_, row) => {
+        const agg = aggMap[row.target_name];
+        const v = agg ? agg.count : null;
+        return v != null ? <span style={{ fontVariantNumeric: 'tabular-nums' }}>{formatCompact(v)}</span> : <span style={{ color: 'var(--text-3)' }}>-</span>;
+      },
+    },
+    {
+      title: '转化人数',
+      key: 'user',
+      align: 'right',
+      render: (_, row) => {
+        const agg = aggMap[row.target_name];
+        const v = agg ? agg.user : null;
+        return v != null ? <span style={{ fontVariantNumeric: 'tabular-nums' }}>{v}</span> : <span style={{ color: 'var(--text-3)' }}>-</span>;
+      },
     },
     {
       title: '转化率',
-      dataIndex: 'rate',
       key: 'rate',
       align: 'right',
-      render: (v) => (v ? (
-        <span style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600, color: 'var(--brand-hover)' }}>{v}%</span>
-      ) : '-'),
+      render: (_, row) => {
+        const agg = aggMap[row.target_name];
+        if (!agg || agg.rate === 0) return <span style={{ color: 'var(--text-3)' }}>-</span>;
+        return <span style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600, color: 'var(--brand-hover)' }}>{agg.rate.toFixed(2)}%</span>;
+      },
     },
   ];
 
@@ -637,7 +672,13 @@ function TargetsTab({ targets, onAddTarget }) {
         rowKey={(row) => row.target_name}
         columns={columns}
         pagination={false}
+        size="middle"
       />
+      {!rateData && (
+        <p style={{ textAlign: 'center', color: 'var(--text-3)', fontSize: 13, marginTop: 16 }}>
+          访问「转化率」Tab 加载数据后，此处将展示各指标的聚合统计
+        </p>
+      )}
     </div>
   );
 }

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -656,16 +656,6 @@ function TargetsTab({ targets, rateData, defaultValue, onAddTarget }) {
         return v != null ? <span style={{ fontVariantNumeric: 'tabular-nums' }}>{v}</span> : <span style={{ color: 'var(--text-3)' }}>-</span>;
       },
     },
-    {
-      title: <Tooltip title="转化人数 ／ 所有版本实验UV之和。同一批用户可能触发多个指标，所以不同指标的转化率可能相同">转化率</Tooltip>,
-      key: 'rate',
-      align: 'right',
-      render: (_, row) => {
-        const agg = aggMap[row.target_name];
-        if (!agg || agg.rate === 0) return <span style={{ color: 'var(--text-3)' }}>-</span>;
-        return <span style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600, color: 'var(--brand-hover)' }}>{agg.rate.toFixed(2)}%</span>;
-      },
-    },
   ];
 
   return (

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -90,6 +90,7 @@ export default function ExperimentDetail() {
   const handleTabChange = (key) => {
     setActiveTab(key);
     if (key === 'rate' && !rateData) fetchRate();
+    if (key === 'targets' && !rateData) fetchRate();
     if (key === 'overview' && !trafficData) fetchTraffic();
   };
 

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -470,11 +470,18 @@ function RateTab({ rateData, rateLoading, defaultValue, onRetry }) {
           t.mean || 0, t.std || 0, t.user || 0, uv,
         );
 
-        const zscore = ZScore(tRealMean, tRealStd, tRealN, dRealMean, dRealStd, dRealN);
-        const pvalue = 2 * getZPercent(-Math.abs(zscore));
-
         const treatmentRate = (t.user || 0) / uv;
         const controlRate = controlRates[target] || 0;
+
+        // 转化率比例检验（用于显著性判定）
+        const { zscore, pvalue } = proportionZTest(
+          t.user || 0, uv,
+          dt.user || 0, defaultRow.uv || 0,
+        );
+
+        // 指标值均值 Z 检验（仅展示）
+        const meanZscore = ZScore(tRealMean, tRealStd, tRealN, dRealMean, dRealStd, dRealN);
+        const meanPvalue = 2 * getZPercent(-Math.abs(meanZscore));
 
         const sig = getSignificance({
           isControl: row.value === defaultValue,
@@ -501,7 +508,12 @@ function RateTab({ rateData, rateLoading, defaultValue, onRetry }) {
               </div>
             {row.value !== defaultValue && (
               <div className="rate-line rate-line-muted" style={{ marginTop: 2 }}>
-                Z: {isNaN(zscore) ? '-' : zscore.toFixed(3)} · p: {isNaN(pvalue) ? '-' : pvalue.toFixed(3)}
+                转化率检验 Z={isNaN(zscore) ? '-' : zscore.toFixed(3)} p={isNaN(pvalue) ? '-' : pvalue.toFixed(3)}
+              </div>
+            )}
+            {row.value !== defaultValue && (
+              <div className="rate-line rate-line-muted">
+                均值检验 Z={isNaN(meanZscore) ? '-' : meanZscore.toFixed(3)} p={isNaN(meanPvalue) ? '-' : meanPvalue.toFixed(3)}
               </div>
             )}
           </div>

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -490,7 +490,7 @@ function RateTab({ rateData, rateLoading, defaultValue, onRetry }) {
               <SignificanceBadge sig={sig} />
             </div>
             <div className="rate-line">转化人数：<b>{t.user || 0}</b></div>
-            <div className="rate-line rate-line-muted">总值：{t.count || 0} · 均值：{tRealMean.toFixed(2)}</div>
+            <div className="rate-line rate-line-muted">总值：{t.count || 0} · 人均：{(t.user ? (t.count / t.user).toFixed(2) : '-')}</div>
             {row.value !== defaultValue && (
               <div className="rate-line rate-line-muted" style={{ marginTop: 2 }}>
                 Z: {isNaN(zscore) ? '-' : zscore.toFixed(3)} · p: {isNaN(pvalue) ? '-' : pvalue.toFixed(3)}

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -347,7 +347,7 @@ function TrafficChart({ trafficData, versions }) {
       point={{ size: 3 }}
       yAxis={{ label: { formatter: (v) => v } }}
       tooltip={{ showCrosshairs: true }}
-      color={['#6366f1', '#818cf8', '#a5b4fc', '#c7d2fe', '#4f46e5']}
+      color={['#6366f1', '#10b981', '#f59e0b', '#3b82f6', '#ec4899']}
       theme={{
         styleSheet: {
           brandColor: '#6366f1',

--- a/src/routes/ExperimentDetail.jsx
+++ b/src/routes/ExperimentDetail.jsx
@@ -636,7 +636,7 @@ function TargetsTab({ targets, rateData, defaultValue, onAddTarget }) {
       render: (v) => <span style={{ fontFamily: '"SF Mono", monospace', fontSize: 13 }}>{v}</span>,
     },
     {
-      title: '触发总量',
+      title: <Tooltip title="所有版本的指标触发值之和">触发总量</Tooltip>,
       key: 'count',
       align: 'right',
       render: (_, row) => {
@@ -646,7 +646,7 @@ function TargetsTab({ targets, rateData, defaultValue, onAddTarget }) {
       },
     },
     {
-      title: '转化人数',
+      title: <Tooltip title="所有版本触发该指标的独立用户数之和">转化人数</Tooltip>,
       key: 'user',
       align: 'right',
       render: (_, row) => {
@@ -656,7 +656,7 @@ function TargetsTab({ targets, rateData, defaultValue, onAddTarget }) {
       },
     },
     {
-      title: '转化率',
+      title: <Tooltip title="转化人数 ／ 所有版本实验UV之和。同一批用户可能触发多个指标，所以不同指标的转化率可能相同">转化率</Tooltip>,
       key: 'rate',
       align: 'right',
       render: (_, row) => {

--- a/src/routes/Experiments.jsx
+++ b/src/routes/Experiments.jsx
@@ -398,38 +398,18 @@ function ExperimentCard({
           <div className="exp-card-label">
             版本流量（{tw.weight.length} 个版本，已分配 {tw.total}%）
           </div>
-          <div className="version-bars">
-            {tw.weight.map(({ value, name, weight }) => {
-              const ver = versions.find(
-                (v) => v.var_name === test.var_name && v.value === value,
-              );
-              return (
-                <Tooltip
-                  key={value}
-                  title={
-                    (name === value ? `${value}` : `${name}(${value})`) +
-                    `: ${weight}%` +
-                    (ver ? `, pv: ${ver.pv || '-'}, uv: ${ver.uv || '-'}` : '')
-                  }
-                >
-                  <div className="version-bar-item">
-                    <div
-                      className="version-bar-fill"
-                      style={{ width: '100%', opacity: weight > 0 ? 1 : 0.35 }}
-                    >
-                      <span>{weight}%</span>
-                    </div>
-                    <span className="version-bar-label">
-                      {name === value ? value : name}
-                    </span>
-                  </div>
-                </Tooltip>
-              );
-            })}
-            {tw.weight.length === 0 && (
-              <span style={{ color: 'var(--text-3)', fontSize: 13 }}>暂未配置版本</span>
-            )}
-          </div>
+          {tw.weight.length > 0 ? (
+            <TrafficBar
+              segments={tw.weight.map(({ value, name, weight }) => ({
+                label: name === value ? value : `${name}(${value})`,
+                weight,
+              }))}
+              height={20}
+              showLabel
+            />
+          ) : (
+            <span style={{ color: 'var(--text-3)', fontSize: 13 }}>暂未配置版本</span>
+          )}
         </div>
 
         {testTargets.length > 0 && (

--- a/src/routes/Experiments.jsx
+++ b/src/routes/Experiments.jsx
@@ -7,7 +7,7 @@
 import React, { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  Button, Collapse, Progress, Tag, Space, Tooltip, Input, Select,
+  Button, Collapse, Tag, Space, Tooltip, Input, Select,
   Table, Segmented,
 } from 'antd';
 import {
@@ -19,6 +19,7 @@ import { getStatusConfig } from '../constants';
 import NewTestModal from '../components/NewTestModal';
 import EditWeightModal from '../components/EditWeightModal';
 import NewVersionModal from '../components/NewVersionModal';
+import TrafficBar from '../components/TrafficBar';
 import { ExperimentsSkeleton } from '../components/Skeletons';
 import EmptyState from '../components/EmptyState';
 
@@ -107,11 +108,9 @@ export default function Experiments() {
             <span className="layer-header-name">{layer}</span>
             <Tag style={{ borderRadius: 6 }}>{layerTests.length} 个实验</Tag>
             <div className="layer-header-bar">
-              <Progress
-                percent={lw.total}
-                size="small"
-                format={(p) => `${p}%`}
-                status={lw.total >= 100 ? 'exception' : 'normal'}
+              <TrafficBar
+                segments={lw.weight.map((w) => ({ label: w.name || w.var_name, weight: w.weight }))}
+                height={20}
               />
             </div>
             <Button type="link" size="small" icon={<PlusOutlined />} onClick={() => openNewTest(layer)}>
@@ -199,7 +198,7 @@ export default function Experiments() {
         width: 160,
         render: (_, row) => {
           const w = row.weight || 0;
-          return <Progress percent={w} size="small" format={(p) => `${p}%`} />;
+          return <TrafficBar segments={[{ weight: w }]} height={18} />;
         },
       },
       {

--- a/src/routes/Experiments.jsx
+++ b/src/routes/Experiments.jsx
@@ -104,16 +104,16 @@ export default function Experiments() {
       return {
         key: layer,
         label: (
-          <div className="layer-header" onClick={(e) => e.stopPropagation()}>
+          <div className="layer-header">
             <span className="layer-header-name">{layer}</span>
             <Tag style={{ borderRadius: 6 }}>{layerTests.length} 个实验</Tag>
-            <div className="layer-header-bar">
+            <div className="layer-header-bar" onClick={(e) => e.stopPropagation()}>
               <TrafficBar
                 segments={lw.weight.map((w) => ({ label: w.name || w.var_name, weight: w.weight }))}
                 height={20}
               />
             </div>
-            <Button type="link" size="small" icon={<PlusOutlined />} onClick={() => openNewTest(layer)}>
+            <Button type="link" size="small" icon={<PlusOutlined />} onClick={(e) => { e.stopPropagation(); openNewTest(layer); }}>
               新建实验
             </Button>
           </div>

--- a/src/routes/Layers.jsx
+++ b/src/routes/Layers.jsx
@@ -3,15 +3,14 @@
  * 表格展示所有流量层、流量分配、实验数
  */
 import React, { useState, useMemo } from 'react';
-import { Button, Table, Progress, Space, Tooltip } from 'antd';
+import { Button, Table, Space, Tooltip } from 'antd';
 import { PlusOutlined, PieChartOutlined } from '@ant-design/icons';
-import { useNavigate } from 'react-router-dom';
 import { useApp } from '../store/AppContext';
+import TrafficBar from '../components/TrafficBar';
 import NewLayerModal from '../components/NewLayerModal';
 import EditLayerWeightModal from '../components/EditLayerWeightModal';
 
 export default function Layers() {
-  const navigate = useNavigate();
   const { layers, layerWeight, tests, loading } = useApp();
   const [showNewLayer, setShowNewLayer] = useState(false);
   const [editLayer, setEditLayer] = useState(null);
@@ -23,6 +22,7 @@ export default function Layers() {
       key: layer,
       name: layer,
       weight: lw.total,
+      segments: lw.weight.map((w) => ({ label: w.name || w.var_name, weight: w.weight })),
       var_count: lw.weight.length,
       test_count: layerTests.length,
       running_count: layerTests.filter((t) => t.status === 'running').length,
@@ -41,17 +41,16 @@ export default function Layers() {
       ),
     },
     {
-      title: '已分配流量',
-      dataIndex: 'weight',
-      key: 'weight',
-      width: 240,
-      render: (v) => (
-        <Progress
-          percent={v}
-          size="small"
-          status={v >= 100 ? 'exception' : 'normal'}
-          format={(p) => `${p}%`}
-        />
+      title: '流量分配',
+      key: 'traffic',
+      width: 280,
+      render: (_, row) => (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <TrafficBar segments={row.segments} height={20} />
+          <span style={{ fontSize: 12, color: '#94a3b8', whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' }}>
+            {row.weight}%
+          </span>
+        </div>
       ),
     },
     {

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -39,6 +39,36 @@ export function ZScore(mean1, std1, n1, mean2, std2, n2) {
 }
 
 /**
+ * 转化率比例检验（Z-test for proportions）
+ *
+ * 比较两个转化率是否有显著差异，用于 AB 测试显著性判定。
+ * 比指标值均值的 Z 检验更符合「转化率是否显著」的直觉。
+ *
+ * @param {number} converters1 - 实验组转化人数
+ * @param {number} n1 - 实验组总 UV
+ * @param {number} converters2 - 对照组转化人数
+ * @param {number} n2 - 对照组总 UV
+ * @returns {{ zscore: number, pvalue: number }}
+ */
+export function proportionZTest(converters1, n1, converters2, n2) {
+  if (n1 <= 0 || n2 <= 0) return { zscore: NaN, pvalue: NaN };
+
+  const p1 = converters1 / n1;
+  const p2 = converters2 / n2;
+  const pooledP = (converters1 + converters2) / (n1 + n2);
+
+  // pooled SE = 0 时（两组都 0 或都 100%），无法检验
+  if (pooledP === 0 || pooledP === 1) return { zscore: NaN, pvalue: NaN };
+
+  const se = Math.sqrt(pooledP * (1 - pooledP) * (1 / n1 + 1 / n2));
+  if (se === 0) return { zscore: NaN, pvalue: NaN };
+
+  const z = (p1 - p2) / se;
+  const p = 2 * getZPercent(-Math.abs(z));
+  return { zscore: z, pvalue: p };
+}
+
+/**
  * 校正均值和标准差
  * 服务端统计的是 target 的均值/方差，需要补齐未触发用户的 0 值
  */


### PR DESCRIPTION
## 概述

新增 TrafficAllocator 流量分配器组件，统一全站流量可视化展示；修正转化率显著性检验方法；完善多项数据展示细节。

## 改动清单

### 流量分配
- **新增 TrafficAllocator 组件**：基于 antd Slider，每个段 max 动态计算为 `100 - 其他段总和`，天然防止总量超额
- **新增 TrafficBar 迷你组件**：彩色分段条 + 斜纹未分配段，用于表格、卡片等紧凑场景
- **统一全站流量展示**：流量层表格、Collapse header、实验卡片版本流量、编辑流量弹窗全部统一为 TrafficBar / TrafficAllocator
- **多色系调色板**：靛蓝/翠绿/琥珀/天蓝/玫红/紫罗兰，不同版本清晰可辨

### 统计检验
- **显著性判定改用转化率比例检验**（two-proportion Z-test），符合 Optimizely/VWO 等主流 AB 平台做法
- 之前的指标值均值 Z 检验（realMeanStd）保留在详情行作为补充参考
- 详情行同时展示两组检验结果：转化率检验 Z/p + 均值检验 Z/p

### 数据展示修正
- 转化率表格：同时展示「人均」(count/user) 和「全量均值」(count/UV) + 标准差
- 指标 Tab：复用 rate 数据展示聚合统计（触发总量/转化人数），点击即自动加载
- 删除指标 Tab 中容易混淆的聚合转化率列
- Tooltip 标注各字段计算方式

### 交互优化
- 弹窗 `maskClosable=false`，防止误触关闭
- 点击层名/Tag 可展开收起 Collapse，按钮和流量条不触发
- 实验卡片 `:active` 触觉反馈
- rate-line `white-space: nowrap` 防止换行

## 新增文件
- `src/components/TrafficAllocator.jsx`
- `src/components/TrafficBar.jsx`

## 修改文件
- `src/utils/stats.js` — 新增 `proportionZTest` 函数
- `src/routes/ExperimentDetail.jsx` — 统计检验、展示逻辑
- `src/routes/Experiments.jsx` — TrafficBar 集成
- `src/routes/Layers.jsx` — TrafficBar 集成
- `src/components/EditWeightModal.jsx` — TrafficAllocator 集成
- `src/components/EditLayerWeightModal.jsx` — TrafficAllocator 集成
- `src/index.css` — 流量条样式